### PR TITLE
fix(schema): remove withTimezone to avoid destructive migration

### DIFF
--- a/drizzle/0024_swift_sage.sql
+++ b/drizzle/0024_swift_sage.sql
@@ -1,4 +1,0 @@
-ALTER TABLE "bingoscape-next_events" ALTER COLUMN "start_date" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
-ALTER TABLE "bingoscape-next_events" ALTER COLUMN "end_date" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
-ALTER TABLE "bingoscape-next_events" ALTER COLUMN "registration_deadline" SET DATA TYPE timestamp with time zone;--> statement-breakpoint
-ALTER TABLE "bingoscape-next_events" ADD COLUMN "timezone" varchar(100) DEFAULT 'UTC' NOT NULL;

--- a/drizzle/0024_workable_ikaris.sql
+++ b/drizzle/0024_workable_ikaris.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "bingoscape-next_events" ALTER COLUMN "start_date" SET DATA TYPE timestamp;--> statement-breakpoint
+ALTER TABLE "bingoscape-next_events" ALTER COLUMN "end_date" SET DATA TYPE timestamp;--> statement-breakpoint
+ALTER TABLE "bingoscape-next_events" ALTER COLUMN "registration_deadline" SET DATA TYPE timestamp;

--- a/drizzle/meta/0024_snapshot.json
+++ b/drizzle/meta/0024_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "1cb830f4-0110-46b5-a8ce-8aae9cc20840",
-  "prevId": "5e65871b-757b-4b52-9595-f1c1b574832c",
+  "id": "617af161-2de9-404c-b3a6-7087a8adc151",
+  "prevId": "1cb830f4-0110-46b5-a8ce-8aae9cc20840",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1378,19 +1378,19 @@
         },
         "start_date": {
           "name": "start_date",
-          "type": "timestamp with time zone",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": true
         },
         "end_date": {
           "name": "end_date",
-          "type": "timestamp with time zone",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": true
         },
         "registration_deadline": {
           "name": "registration_deadline",
-          "type": "timestamp with time zone",
+          "type": "timestamp",
           "primaryKey": false,
           "notNull": false
         },

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -173,8 +173,8 @@
     {
       "idx": 24,
       "version": "7",
-      "when": 1783202122767,
-      "tag": "0024_swift_sage",
+      "when": 1783208174745,
+      "tag": "0024_workable_ikaris",
       "breakpoints": true
     }
   ]

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -210,11 +210,10 @@ export const events = createTable("events", {
   id: uuid("id").defaultRandom().primaryKey(),
   title: varchar("name", { length: 255 }).notNull(),
   description: varchar("description", { length: 1000 }),
-  startDate: timestamp("start_date", { mode: "date", withTimezone: true }).notNull(),
-  endDate: timestamp("end_date", { mode: "date", withTimezone: true }).notNull(),
+  startDate: timestamp("start_date", { mode: "date" }).notNull(),
+  endDate: timestamp("end_date", { mode: "date" }).notNull(),
   registrationDeadline: timestamp("registration_deadline", {
     mode: "date",
-    withTimezone: true,
   }),
   timezone: varchar("timezone", { length: 100 }).notNull().default("UTC"),
   creatorId: uuid("creator_id").references(() => users.id, {


### PR DESCRIPTION
Removes withTimezone: true from event date fields to prevent Drizzle from attempting an ALTER COLUMN type change, which was causing destructive migration warnings during db:push.