### PR TITLE
Set expiresInDays default to 0 so downstream can pick it up as Unlimited

### DIFF
--- a/src/components/generate-clan-invite-link.tsx
+++ b/src/components/generate-clan-invite-link.tsx
@@ -47,7 +47,7 @@ export function GenerateClanInviteLink({ clanId }: { clanId: string }) {
     setIsLoading(true)
     try {
       // Calculate actual values
-      let expiresInDays: number | null = null
+      let expiresInDays: number | null = 0
       if (formData.expiresInDays === "custom") {
         expiresInDays = parseInt(formData.customDays) || null
       } else if (formData.expiresInDays !== "0") {


### PR DESCRIPTION
This is to fix this issue: https://github.com/bingoscape/bingoscape/issues/28

Form was POSTing expiresInDays as `null` which downstream was setting it to 7 as default, example JSON:

`{"label":"TestPR","expiresInDays":null,"maxUses":null}`


Setting expiresInDays to 0 allows it to POST correctly to the API which makes it get set to unlimited, new example JSON:
`{"label":"TestPR","expiresInDays":0,"maxUses":null}`



Tested with different combinations of maxUses and expiresInDays, looks to be working correctly.