### PR TITLE
docs: setup AI agent skills and domain glossary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,13 @@
 - Images stored in `public/uploads/` with absolute paths in DB
 - Console removed in production builds
 - Sentry integration for error tracking
+
+## Agent skills
+
+### Issue tracker
+
+GitHub issues (using the `gh` CLI). See `docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+Single-context. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,63 @@
+# Bingoscape
+
+The core domain model for the Bingoscape OSRS bingo platform.
+
+## Language
+
+**Event**:
+A top-level bingo competition.
+_Avoid_: Game, Bingo, Competition
+
+**Team**:
+A group of one or more players participating together in an Event.
+_Avoid_: Clan, Group, Party
+
+**Board**:
+The grid of challenges played during an Event. (Note: The database refers to this entity as `bingos`.)
+_Avoid_: Grid, Card, Bingo
+
+**Tile**:
+An individual square or challenge on a Board.
+_Avoid_: Task, Drop, Square
+
+**Submission**:
+A claim by a Team that they have completed a Tile. Can be manual (requiring admin approval) or automatic (instantly approved).
+_Avoid_: Proof, Drop
+
+**RuneLite Plugin**:
+The official OSRS client integration that sends Submissions either manually or via automatic drop detection.
+
+**Player**:
+A participant in Bingoscape. A Player can only belong to one Team per Event. Their OSRS username is tracked, but if it changes, it currently requires manual updates in Bingoscape and Wise Old Man.
+_Avoid_: User, Account
+
+**Wise Old Man**:
+The external OSRS group and stat tracking service integrated with Bingoscape.
+
+**Clan**:
+A persistent, long-term group of Players outside of any specific Event.
+_Avoid_: Group, Guild
+
+**Goal**:
+The specific requirement(s) needed to complete a Tile (e.g., obtaining an item, gaining XP). Goals can be grouped logically (AND/OR/SUM).
+_Avoid_: Requirement, Objective
+
+**Prize Pool**:
+The total OSRS GP available to be won in an Event, combining the base amount, Buy-Ins, and Donations.
+
+**Buy-In**:
+The entry fee to participate in an Event, paid in OSRS GP.
+
+**Donation**:
+Additional OSRS GP voluntarily contributed to an Event's Prize Pool.
+
+**XP**:
+The scoring metric earned by Teams for completing Tiles and securing Bonuses.
+_Avoid_: Points, Score
+
+**Bonus**:
+Extra XP awarded for completing a specific pattern on the Board. Typically defined as a **Row Bonus**, **Column Bonus**, or **Diagonal Bonus**.
+_Avoid_: Line Bonus
+
+**Tier**:
+A grouping of Tiles used in progressive bingos. Higher Tiers remain locked until a Team earns enough XP to unlock them.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.


### PR DESCRIPTION
Configure GitHub as issue tracker for agent skills. Establish CONTEXT.md to enforce ubiquitous language for OSRS bingo concepts (Event, Team, Board, Submission) across AI sessions.